### PR TITLE
Fix corrupted import in auth route backup

### DIFF
--- a/cloud_drift_analyzer/api/routes/auth.py.bak
+++ b/cloud_drift_analyzer/api/routes/auth.py.bak
@@ -1,12 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy impo@router.post("/change-password")
-async def change_password(
-    password_data: PasswordChange,
-    current_user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
-):ect
+from sqlalchemy import select
 from datetime import datetime, timedelta, timezone
 import jwt
 


### PR DESCRIPTION
## Summary
- clean up `cloud_drift_analyzer/api/routes/auth.py.bak`
- restore valid SQLAlchemy import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855c260cb5c8329ae2e438da1d90637